### PR TITLE
Fix for Magento patch SUPEE-6788

### DIFF
--- a/app/code/community/Ecocode/Minify/etc/config.xml
+++ b/app/code/community/Ecocode/Minify/etc/config.xml
@@ -75,13 +75,13 @@
     </global>
     <admin>
         <routers>
-            <ecocode_minify>
-                <use>admin</use>
+            <adminhtml>
                 <args>
-                    <module>Ecocode_Minify</module>
-                    <frontName>EcoMinify</frontName>
+                    <modules>
+                        <ecocode_minify after="Mage_Adminhtml">EcocodeMinify_Adminhtml</ecocode_minify>
+                    </modules>
                 </args>
-            </ecocode_minify>
+            </adminhtml>
         </routers>
     </admin>
     <adminhtml>


### PR DESCRIPTION
This should make the extension compatible with Magento's security patch 6788.
More information here: https://info2.magento.com/rs/318-XBX-392/images/SUPEE-6788-Technical%20Details.pdf
And here: https://www.byte.nl/kennisbank/item/magento-patch-supee-6788-installeren-2